### PR TITLE
Made name optional for garments and outfits

### DIFF
--- a/src/dal/entity/garment.entity.ts
+++ b/src/dal/entity/garment.entity.ts
@@ -21,8 +21,8 @@ export class Garment extends ShareableId {
   @PrimaryKey()
   public id!: number;
 
-  @Property()
-  public name!: string;
+  @Property({ nullable: true })
+  public name?: string;
 
   @Property()
   public category!: string;

--- a/src/dal/entity/outfit.entity.ts
+++ b/src/dal/entity/outfit.entity.ts
@@ -21,8 +21,8 @@ export class Outfit extends ShareableId {
   @PrimaryKey()
   public id!: number;
 
-  @Property()
-  public name!: string;
+  @Property({ nullable: true })
+  public name?: string;
 
   @Property({ nullable: true })
   public notes?: string;

--- a/src/dal/migrations/postgres/.snapshot-postgres.json
+++ b/src/dal/migrations/postgres/.snapshot-postgres.json
@@ -230,7 +230,7 @@
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
-          "nullable": false,
+          "nullable": true,
           "length": 255,
           "mappedType": "string"
         },
@@ -566,7 +566,7 @@
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
-          "nullable": false,
+          "nullable": true,
           "length": 255,
           "mappedType": "string"
         },

--- a/src/dal/migrations/postgres/Migration20260416215256.ts
+++ b/src/dal/migrations/postgres/Migration20260416215256.ts
@@ -1,0 +1,21 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260416215256 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table "outfit" alter column "name" type varchar(255) using ("name"::varchar(255));`);
+    this.addSql(`alter table "outfit" alter column "name" drop not null;`);
+
+    this.addSql(`alter table "garment" alter column "name" type varchar(255) using ("name"::varchar(255));`);
+    this.addSql(`alter table "garment" alter column "name" drop not null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table "outfit" alter column "name" type varchar(255) using ("name"::varchar(255));`);
+    this.addSql(`alter table "outfit" alter column "name" set not null;`);
+
+    this.addSql(`alter table "garment" alter column "name" type varchar(255) using ("name"::varchar(255));`);
+    this.addSql(`alter table "garment" alter column "name" set not null;`);
+  }
+
+}

--- a/src/dal/migrations/sqlite/.snapshot-sqlite3.db.json
+++ b/src/dal/migrations/sqlite/.snapshot-sqlite3.db.json
@@ -233,7 +233,7 @@
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
-          "nullable": false,
+          "nullable": true,
           "length": null,
           "mappedType": "text"
         },
@@ -618,7 +618,7 @@
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
-          "nullable": false,
+          "nullable": true,
           "length": null,
           "mappedType": "text"
         },

--- a/src/dal/migrations/sqlite/Migration20260416215236.ts
+++ b/src/dal/migrations/sqlite/Migration20260416215236.ts
@@ -9,7 +9,8 @@ export class Migration20260416215236 extends Migration {
     this.addSql(`drop table \`outfit\`;`);
     this.addSql(`alter table \`outfit__temp_alter\` rename to \`outfit\`;`);
     this.addSql(`create index \`outfit_owner_id_index\` on \`outfit\` (\`owner_id\`);`);
-    this.addSql(`pragma foreign_keys = on;pragma foreign_keys = off;`);
+    this.addSql(`pragma foreign_keys = on;`);
+    this.addSql(`pragma foreign_keys = off;`);
     this.addSql(`create table \`garment__temp_alter\` (\`id\` integer not null primary key autoincrement, \`shareable_id\` text not null, \`flagged\` integer null, \`banned\` integer null, \`name\` text null, \`category\` text not null, \`color\` text null, \`brand\` text null, \`size\` text null, \`notes\` text null, \`photo_id\` integer null, \`owner_id\` integer null, constraint \`garment_photo_id_foreign\` foreign key(\`photo_id\`) references \`file\`(\`id\`) on delete set null on update cascade, constraint \`garment_owner_id_foreign\` foreign key(\`owner_id\`) references \`user\`(\`id\`) on delete cascade on update cascade);`);
     this.addSql(`insert into \`garment__temp_alter\` select \`id\`, \`shareable_id\`, \`flagged\`, \`banned\`, \`name\`, \`category\`, \`color\`, \`brand\`, \`size\`, \`notes\`, \`photo_id\`, \`owner_id\` from \`garment\`;`);
     this.addSql(`drop table \`garment\`;`);

--- a/src/dal/migrations/sqlite/Migration20260416215236.ts
+++ b/src/dal/migrations/sqlite/Migration20260416215236.ts
@@ -1,0 +1,22 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260416215236 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`pragma foreign_keys = off;`);
+    this.addSql(`create table \`outfit__temp_alter\` (\`id\` integer not null primary key autoincrement, \`shareable_id\` text not null, \`flagged\` integer null, \`banned\` integer null, \`name\` text null, \`notes\` text null, \`slots\` json null, \`owner_id\` integer null, constraint \`outfit_owner_id_foreign\` foreign key(\`owner_id\`) references \`user\`(\`id\`) on delete cascade on update cascade);`);
+    this.addSql(`insert into \`outfit__temp_alter\` select \`id\`, \`shareable_id\`, \`flagged\`, \`banned\`, \`name\`, \`notes\`, \`slots\`, \`owner_id\` from \`outfit\`;`);
+    this.addSql(`drop table \`outfit\`;`);
+    this.addSql(`alter table \`outfit__temp_alter\` rename to \`outfit\`;`);
+    this.addSql(`create index \`outfit_owner_id_index\` on \`outfit\` (\`owner_id\`);`);
+    this.addSql(`pragma foreign_keys = on;pragma foreign_keys = off;`);
+    this.addSql(`create table \`garment__temp_alter\` (\`id\` integer not null primary key autoincrement, \`shareable_id\` text not null, \`flagged\` integer null, \`banned\` integer null, \`name\` text null, \`category\` text not null, \`color\` text null, \`brand\` text null, \`size\` text null, \`notes\` text null, \`photo_id\` integer null, \`owner_id\` integer null, constraint \`garment_photo_id_foreign\` foreign key(\`photo_id\`) references \`file\`(\`id\`) on delete set null on update cascade, constraint \`garment_owner_id_foreign\` foreign key(\`owner_id\`) references \`user\`(\`id\`) on delete cascade on update cascade);`);
+    this.addSql(`insert into \`garment__temp_alter\` select \`id\`, \`shareable_id\`, \`flagged\`, \`banned\`, \`name\`, \`category\`, \`color\`, \`brand\`, \`size\`, \`notes\`, \`photo_id\`, \`owner_id\` from \`garment\`;`);
+    this.addSql(`drop table \`garment\`;`);
+    this.addSql(`alter table \`garment__temp_alter\` rename to \`garment\`;`);
+    this.addSql(`create unique index \`garment_photo_id_unique\` on \`garment\` (\`photo_id\`);`);
+    this.addSql(`create index \`garment_owner_id_index\` on \`garment\` (\`owner_id\`);`);
+    this.addSql(`pragma foreign_keys = on;`);
+  }
+
+}

--- a/src/wardrobe/dto/create-garment.dto.ts
+++ b/src/wardrobe/dto/create-garment.dto.ts
@@ -3,7 +3,7 @@ import { Observable } from 'rxjs';
 import { MultipartFileStream } from '@proventuslabs/nestjs-multipart-form';
 
 export interface CreateGarmentDto {
-  name: string;
+  name?: string;
   category: string;
   brand?: string;
   color?: GarmentColor;

--- a/src/wardrobe/dto/create-outfit.dto.ts
+++ b/src/wardrobe/dto/create-outfit.dto.ts
@@ -1,0 +1,7 @@
+import { OutfitSlot } from 'src/dal/entity/outfit.entity';
+
+export interface CreateOutfitDto {
+  name?: string;
+  notes?: string;
+  slots?: OutfitSlot[];
+}

--- a/src/wardrobe/dto/update-outfit.dto.ts
+++ b/src/wardrobe/dto/update-outfit.dto.ts
@@ -1,0 +1,7 @@
+import { OutfitSlot } from 'src/dal/entity/outfit.entity';
+
+export interface UpdateOutfitDto {
+  name?: string;
+  notes?: string;
+  slots?: OutfitSlot[];
+}

--- a/src/wardrobe/outfit.controller.ts
+++ b/src/wardrobe/outfit.controller.ts
@@ -72,7 +72,7 @@ export class OutfitController {
   async create(
     @Body()
     body: {
-      name: string;
+      name?: string;
       notes?: string;
       scheduleDate?: string;
       category?: string | string[];

--- a/src/wardrobe/outfit.service.ts
+++ b/src/wardrobe/outfit.service.ts
@@ -12,19 +12,8 @@ import { Outfit, OutfitSlot } from '../dal/entity/outfit.entity';
 import { User } from '../dal/entity/user.entity';
 import { GarmentCategory } from './garment-category.enum';
 import { GarmentService } from './garment.service';
-
-export interface CreateOutfitDto {
-  name: string;
-  notes?: string;
-  slots?: OutfitSlot[];
-}
-
-export interface UpdateOutfitDto {
-  name?: string;
-  notes?: string;
-  slots?: OutfitSlot[];
-}
-
+import { CreateOutfitDto } from './dto/create-outfit.dto';
+import { UpdateOutfitDto } from './dto/update-outfit.dto';
 @Injectable()
 export class OutfitService {
   private readonly logger = new Logger(OutfitService.name);

--- a/src/wardrobe/wardrobe.controller.ts
+++ b/src/wardrobe/wardrobe.controller.ts
@@ -94,7 +94,7 @@ export class WardrobeController {
   async create(
     @Body()
     body: {
-      name: string;
+      name?: string;
       category: string;
       brand?: string;
       color?: GarmentColor;

--- a/views/outfits/form.hbs
+++ b/views/outfits/form.hbs
@@ -82,7 +82,6 @@
         class="input input-bordered w-full"
         value="{{#if outfit}}{{outfit.name}}{{/if}}"
         placeholder="e.g. Summer Date Night"
-        required
       />
     </div>
 

--- a/views/wardrobe/form.hbs
+++ b/views/wardrobe/form.hbs
@@ -18,13 +18,12 @@
     class="flex flex-col gap-4"
   >
     <div class="form-control">
-      <label class="label"><span class="label-text">{{t 'lang.NAME'}} *</span></label>
+      <label class="label"><span class="label-text">{{t 'lang.NAME'}}</span></label>
       <input
         type="text"
         name="name"
         class="input input-bordered"
         value="{{#if garment}}{{garment.name}}{{/if}}"
-        required
         placeholder="e.g. Black Linen Blazer"
       />
     </div>


### PR DESCRIPTION
- removed required from name input fields for both outfit form and garment form
- made name nullable for both outfit entity and outfit dto
- made name nullable for both garment entity and garment dto
- generated migrations from CLI for postgres and sqlite
- pulled out inline dto's for outfit entity into their own files to match only one export per file pattern