### PR TITLE
Garment Date of Acquisition

### DIFF
--- a/src/dal/entity/garment.entity.ts
+++ b/src/dal/entity/garment.entity.ts
@@ -37,6 +37,9 @@ export class Garment extends ShareableId {
   @Property({ nullable: true })
   public size?: string;
 
+  @Property({ type: Date, nullable: true })
+  public dateAquired?: Date;
+
   @Property({ nullable: true })
   public notes?: string;
 

--- a/src/dal/migrations/postgres/.snapshot-postgres.json
+++ b/src/dal/migrations/postgres/.snapshot-postgres.json
@@ -882,6 +882,22 @@
           "enumItems": [],
           "mappedType": "string"
         },
+        "date_aquired": {
+          "name": "date_aquired",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
         "notes": {
           "name": "notes",
           "type": "varchar(255)",

--- a/src/dal/migrations/postgres/Migration20260617003819.ts
+++ b/src/dal/migrations/postgres/Migration20260617003819.ts
@@ -1,0 +1,13 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260617003819 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table "garment" add column "date_aquired" timestamptz null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table "garment" drop column "date_aquired";`);
+  }
+
+}

--- a/src/dal/migrations/sqlite/.snapshot-sqlite3.db.json
+++ b/src/dal/migrations/sqlite/.snapshot-sqlite3.db.json
@@ -914,6 +914,22 @@
           "enumItems": [],
           "mappedType": "text"
         },
+        "date_aquired": {
+          "name": "date_aquired",
+          "type": "datetime",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
         "notes": {
           "name": "notes",
           "type": "text",

--- a/src/dal/migrations/sqlite/Migration20260617003818.ts
+++ b/src/dal/migrations/sqlite/Migration20260617003818.ts
@@ -1,0 +1,9 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260617003818 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table \`garment\` add column \`date_aquired\` datetime null;`);
+  }
+
+}

--- a/src/i18n/de/lang.json
+++ b/src/i18n/de/lang.json
@@ -97,6 +97,7 @@
   "BG_STAGE_ENCODING": "Ergebnis wird kodiert…",
   "BG_HINT_TYPICAL_DURATION": "Auf Mobilgeräten kann das einen Moment dauern.",
   "BG_HINT_STILL_WORKING": "Es wird noch gearbeitet. Besonders auf iPhone und iPad kann es etwas dauern.",
+  "DATE_AQUIRED": "Erworben am",
   "CONFIRM_DELETE": "Bist du sicher, dass du das löschen möchtest?",
   "SEARCH_PLACEHOLDER": "Kleidungsstücke suchen...",
   "SEARCH": "Suchen",

--- a/src/i18n/en/lang.json
+++ b/src/i18n/en/lang.json
@@ -104,6 +104,7 @@
   "MASK_BRUSH_ERASE": "Erase",
   "MASK_BRUSH_RESTORE": "Restore",
   "MASK_BRUSH_SIZE": "Size",
+  "DATE_AQUIRED": "Date Acquired",
   "CONFIRM_DELETE": "Are you sure you want to delete this?",
   "SEARCH_PLACEHOLDER": "Search garments...",
   "SEARCH": "Search",

--- a/src/i18n/es/lang.json
+++ b/src/i18n/es/lang.json
@@ -97,6 +97,7 @@
   "BG_STAGE_ENCODING": "Codificando resultado…",
   "BG_HINT_TYPICAL_DURATION": "Esto puede tardar un momento en móvil.",
   "BG_HINT_STILL_WORKING": "Sigue trabajando. Especialmente en iPhone e iPad puede tardar un poco.",
+  "DATE_AQUIRED": "Fecha de Adquisición",
   "CONFIRM_DELETE": "¿Estás seguro de que deseas eliminar esto?",
   "SEARCH_PLACEHOLDER": "Buscar prendas...",
   "SEARCH": "Buscar",

--- a/src/i18n/fr/lang.json
+++ b/src/i18n/fr/lang.json
@@ -97,6 +97,7 @@
   "BG_STAGE_ENCODING": "Encodage du résultat…",
   "BG_HINT_TYPICAL_DURATION": "Cela peut prendre un moment sur mobile.",
   "BG_HINT_STILL_WORKING": "Toujours en cours. En particulier sur iPhone et iPad, cela peut prendre un peu de temps.",
+  "DATE_AQUIRED": "Date d'Acquisition",
   "CONFIRM_DELETE": "Êtes-vous sûr de vouloir supprimer ceci ?",
   "SEARCH_PLACEHOLDER": "Rechercher des vêtements...",
   "SEARCH": "Rechercher",

--- a/src/i18n/it/lang.json
+++ b/src/i18n/it/lang.json
@@ -97,6 +97,7 @@
   "BG_STAGE_ENCODING": "Codifica risultato…",
   "BG_HINT_TYPICAL_DURATION": "Su mobile potrebbe richiedere qualche istante.",
   "BG_HINT_STILL_WORKING": "Ancora in corso. Soprattutto su iPhone e iPad potrebbe richiedere piu tempo.",
+  "DATE_AQUIRED": "Data di Acquisizione",
   "CONFIRM_DELETE": "Sei sicuro di voler eliminare questo?",
   "SEARCH_PLACEHOLDER": "Cerca capi...",
   "SEARCH": "Cerca",

--- a/src/i18n/ru/lang.json
+++ b/src/i18n/ru/lang.json
@@ -97,6 +97,7 @@
   "BG_STAGE_ENCODING": "Кодирование результата…",
   "BG_HINT_TYPICAL_DURATION": "Это может занять некоторое время на мобильных устройствах.",
   "BG_HINT_STILL_WORKING": "Всё ещё работаем. Особенно долго это может занимать на iPhone и iPad.",
+  "DATE_AQUIRED": "Дата приобретения",
   "CONFIRM_DELETE": "Вы уверены, что хотите удалить это?",
   "SEARCH_PLACEHOLDER": "Поиск вещей...",
   "SEARCH": "Поиск",

--- a/src/main.ts
+++ b/src/main.ts
@@ -126,6 +126,11 @@ async function bootstrap() {
       return arg1 == arg2 ? options.fn(this) : options.inverse(this);
     },
   );
+  hbs.registerHelper('formatDate', (date: string | Date | undefined) => {
+    if (!date) return '';
+    const d = date instanceof Date ? date : new Date(date);
+    return d.toISOString().split('T')[0];
+  });
   hbs.registerHelper('uri', (str: string) =>
     encodeURIComponent(String(str ?? '')),
   );

--- a/src/wardrobe/dto/create-garment.dto.ts
+++ b/src/wardrobe/dto/create-garment.dto.ts
@@ -8,5 +8,6 @@ export interface CreateGarmentDto {
   color?: GarmentColor;
   size?: string;
   notes?: string;
+  dateAquired?: string;
   files?: AsyncIterableIterator<MultipartFile>;
 }

--- a/src/wardrobe/dto/update-garment.dto.ts
+++ b/src/wardrobe/dto/update-garment.dto.ts
@@ -8,5 +8,6 @@ export interface UpdateGarmentDto {
   color?: GarmentColor;
   size?: string;
   notes?: string;
+  dateAquired?: string;
   files?: AsyncIterableIterator<MultipartFile>;
 }

--- a/src/wardrobe/garment.service.ts
+++ b/src/wardrobe/garment.service.ts
@@ -144,6 +144,7 @@ export class GarmentService {
       color: dto.color,
       size: this.normalizeSize(dto.size),
       notes: dto.notes,
+      dateAquired: dto.dateAquired ? new Date(dto.dateAquired) : undefined,
       photo: photo ?? undefined,
     });
 
@@ -245,6 +246,10 @@ export class GarmentService {
     if ('color' in dto) garment.color = dto.color;
     if ('size' in dto) garment.size = this.normalizeSize(dto.size);
     if ('notes' in dto) garment.notes = dto.notes;
+    if ('dateAquired' in dto)
+      garment.dateAquired = dto.dateAquired
+        ? new Date(dto.dateAquired)
+        : undefined;
 
     await this.garmentRepository.getEntityManager().flush();
     return garment;

--- a/src/wardrobe/wardrobe.controller.ts
+++ b/src/wardrobe/wardrobe.controller.ts
@@ -140,6 +140,7 @@ export class WardrobeController {
       color?: GarmentColor;
       size?: string;
       notes?: string;
+      dateAquired?: string;
     },
     @Req() req: FastifyRequest,
     @Res() reply: FastifyReply,
@@ -161,6 +162,7 @@ export class WardrobeController {
         color: body.color,
         size: body.size,
         notes: body.notes,
+        dateAquired: body.dateAquired,
       },
       viewOwner ?? userId,
     );
@@ -253,6 +255,7 @@ export class WardrobeController {
       color?: GarmentColor;
       size?: string;
       notes?: string;
+      dateAquired?: string;
     },
     @Req() req: FastifyRequest,
     @Res() reply: FastifyReply,
@@ -275,6 +278,7 @@ export class WardrobeController {
         color: body.color,
         size: body.size,
         notes: body.notes,
+        dateAquired: body.dateAquired,
       },
       viewOwner ?? userId,
       userId,

--- a/views/wardrobe/form.hbs
+++ b/views/wardrobe/form.hbs
@@ -80,6 +80,16 @@
     </div>
 
     <div class="form-control">
+      <label class="label"><span class="label-text">{{t 'lang.DATE_AQUIRED'}}</span></label>
+      <input
+        type="date"
+        name="dateAquired"
+        class="input input-bordered"
+        value="{{formatDate garment.dateAquired}}"
+      />
+    </div>
+
+    <div class="form-control">
       <label class="label"><span class="label-text">{{t 'lang.NOTES'}}</span></label>
       <textarea
         name="notes"

--- a/views/wardrobe/show.hbs
+++ b/views/wardrobe/show.hbs
@@ -180,10 +180,15 @@
         <span class="text-base-content/60 text-sm">{{t 'lang.SIZE'}}</span>
         <span class="font-medium">{{garment.size}}</span>
       </div>
-      {{/if}} {{#if garment.color}}
+      {{/if}}       {{#if garment.color}}
       <div class="flex justify-between">
         <span class="text-base-content/60 text-sm">{{t 'lang.COLOR'}}</span>
         <span class="capitalize font-medium">{{garment.color}}</span>
+      </div>
+      {{/if}} {{#if garment.dateAquired}}
+      <div class="flex justify-between">
+        <span class="text-base-content/60 text-sm">{{t 'lang.DATE_AQUIRED'}}</span>
+        <span class="font-medium">{{formatDate garment.dateAquired}}</span>
       </div>
       {{/if}} {{#if garment.notes}}
       <div class="flex flex-col gap-1">


### PR DESCRIPTION
Closes #74

## Garment Date of Acquisition

Adds an optional `dateAquired` field to track when a garment was acquired.

### Changes
- **`dateAquired` Date property** on Garment entity (optional, nullable)
- **Date input** in garment create/edit form
- **Date display** on garment show page metadata card
- **`formatDate` Handlebars helper** for YYYY-MM-DD formatting
- **i18n keys** for all 6 supported languages
- **SQLite & PostgreSQL migrations**