### PR TITLE
Garment Washing Details

### DIFF
--- a/src/dal/entity/garment.entity.ts
+++ b/src/dal/entity/garment.entity.ts
@@ -40,6 +40,9 @@ export class Garment extends ShareableId {
   @Property({ nullable: true })
   public notes?: string;
 
+  @Property({ nullable: true, columnType: 'text' })
+  public washingDetails?: string;
+
   @OneToOne({
     entity: () => File,
     nullable: true,

--- a/src/dal/migrations/postgres/.snapshot-postgres.json
+++ b/src/dal/migrations/postgres/.snapshot-postgres.json
@@ -898,6 +898,22 @@
           "enumItems": [],
           "mappedType": "string"
         },
+        "washing_details": {
+          "name": "washing_details",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
         "photo_id": {
           "name": "photo_id",
           "type": "int",

--- a/src/dal/migrations/postgres/Migration20260617011648.ts
+++ b/src/dal/migrations/postgres/Migration20260617011648.ts
@@ -1,0 +1,13 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260617011648 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table "garment" add column "washing_details" text null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table "garment" drop column "washing_details";`);
+  }
+
+}

--- a/src/dal/migrations/sqlite/.snapshot-sqlite3.db.json
+++ b/src/dal/migrations/sqlite/.snapshot-sqlite3.db.json
@@ -930,6 +930,22 @@
           "enumItems": [],
           "mappedType": "text"
         },
+        "washing_details": {
+          "name": "washing_details",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
         "photo_id": {
           "name": "photo_id",
           "type": "integer",

--- a/src/dal/migrations/sqlite/Migration20260617011647.ts
+++ b/src/dal/migrations/sqlite/Migration20260617011647.ts
@@ -1,0 +1,9 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260617011647 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table \`garment\` add column \`washing_details\` text null;`);
+  }
+
+}

--- a/src/i18n/de/lang.json
+++ b/src/i18n/de/lang.json
@@ -97,6 +97,7 @@
   "BG_STAGE_ENCODING": "Ergebnis wird kodiert…",
   "BG_HINT_TYPICAL_DURATION": "Auf Mobilgeräten kann das einen Moment dauern.",
   "BG_HINT_STILL_WORKING": "Es wird noch gearbeitet. Besonders auf iPhone und iPad kann es etwas dauern.",
+  "WASHING_DETAILS": "Waschhinweise",
   "CONFIRM_DELETE": "Bist du sicher, dass du das löschen möchtest?",
   "SEARCH_PLACEHOLDER": "Kleidungsstücke suchen...",
   "SEARCH": "Suchen",

--- a/src/i18n/en/lang.json
+++ b/src/i18n/en/lang.json
@@ -104,6 +104,7 @@
   "MASK_BRUSH_ERASE": "Erase",
   "MASK_BRUSH_RESTORE": "Restore",
   "MASK_BRUSH_SIZE": "Size",
+  "WASHING_DETAILS": "Washing Details",
   "CONFIRM_DELETE": "Are you sure you want to delete this?",
   "SEARCH_PLACEHOLDER": "Search garments...",
   "SEARCH": "Search",

--- a/src/i18n/es/lang.json
+++ b/src/i18n/es/lang.json
@@ -97,6 +97,7 @@
   "BG_STAGE_ENCODING": "Codificando resultado…",
   "BG_HINT_TYPICAL_DURATION": "Esto puede tardar un momento en móvil.",
   "BG_HINT_STILL_WORKING": "Sigue trabajando. Especialmente en iPhone e iPad puede tardar un poco.",
+  "WASHING_DETAILS": "Instrucciones de Lavado",
   "CONFIRM_DELETE": "¿Estás seguro de que deseas eliminar esto?",
   "SEARCH_PLACEHOLDER": "Buscar prendas...",
   "SEARCH": "Buscar",

--- a/src/i18n/fr/lang.json
+++ b/src/i18n/fr/lang.json
@@ -97,6 +97,7 @@
   "BG_STAGE_ENCODING": "Encodage du résultat…",
   "BG_HINT_TYPICAL_DURATION": "Cela peut prendre un moment sur mobile.",
   "BG_HINT_STILL_WORKING": "Toujours en cours. En particulier sur iPhone et iPad, cela peut prendre un peu de temps.",
+  "WASHING_DETAILS": "Instructions de Lavage",
   "CONFIRM_DELETE": "Êtes-vous sûr de vouloir supprimer ceci ?",
   "SEARCH_PLACEHOLDER": "Rechercher des vêtements...",
   "SEARCH": "Rechercher",

--- a/src/i18n/it/lang.json
+++ b/src/i18n/it/lang.json
@@ -97,6 +97,7 @@
   "BG_STAGE_ENCODING": "Codifica risultato…",
   "BG_HINT_TYPICAL_DURATION": "Su mobile potrebbe richiedere qualche istante.",
   "BG_HINT_STILL_WORKING": "Ancora in corso. Soprattutto su iPhone e iPad potrebbe richiedere piu tempo.",
+  "WASHING_DETAILS": "Istruzioni di Lavaggio",
   "CONFIRM_DELETE": "Sei sicuro di voler eliminare questo?",
   "SEARCH_PLACEHOLDER": "Cerca capi...",
   "SEARCH": "Cerca",

--- a/src/i18n/ru/lang.json
+++ b/src/i18n/ru/lang.json
@@ -97,6 +97,7 @@
   "BG_STAGE_ENCODING": "Кодирование результата…",
   "BG_HINT_TYPICAL_DURATION": "Это может занять некоторое время на мобильных устройствах.",
   "BG_HINT_STILL_WORKING": "Всё ещё работаем. Особенно долго это может занимать на iPhone и iPad.",
+  "WASHING_DETAILS": "Инструкции по стирке",
   "CONFIRM_DELETE": "Вы уверены, что хотите удалить это?",
   "SEARCH_PLACEHOLDER": "Поиск вещей...",
   "SEARCH": "Поиск",

--- a/src/wardrobe/dto/create-garment.dto.ts
+++ b/src/wardrobe/dto/create-garment.dto.ts
@@ -8,5 +8,6 @@ export interface CreateGarmentDto {
   color?: GarmentColor;
   size?: string;
   notes?: string;
+  washingDetails?: string;
   files?: AsyncIterableIterator<MultipartFile>;
 }

--- a/src/wardrobe/dto/update-garment.dto.ts
+++ b/src/wardrobe/dto/update-garment.dto.ts
@@ -8,5 +8,6 @@ export interface UpdateGarmentDto {
   color?: GarmentColor;
   size?: string;
   notes?: string;
+  washingDetails?: string;
   files?: AsyncIterableIterator<MultipartFile>;
 }

--- a/src/wardrobe/garment.service.ts
+++ b/src/wardrobe/garment.service.ts
@@ -144,6 +144,7 @@ export class GarmentService {
       color: dto.color,
       size: this.normalizeSize(dto.size),
       notes: dto.notes,
+      washingDetails: dto.washingDetails,
       photo: photo ?? undefined,
     });
 
@@ -245,6 +246,7 @@ export class GarmentService {
     if ('color' in dto) garment.color = dto.color;
     if ('size' in dto) garment.size = this.normalizeSize(dto.size);
     if ('notes' in dto) garment.notes = dto.notes;
+    if ('washingDetails' in dto) garment.washingDetails = dto.washingDetails;
 
     await this.garmentRepository.getEntityManager().flush();
     return garment;

--- a/src/wardrobe/wardrobe.controller.ts
+++ b/src/wardrobe/wardrobe.controller.ts
@@ -140,6 +140,7 @@ export class WardrobeController {
       color?: GarmentColor;
       size?: string;
       notes?: string;
+      washingDetails?: string;
     },
     @Req() req: FastifyRequest,
     @Res() reply: FastifyReply,
@@ -161,6 +162,7 @@ export class WardrobeController {
         color: body.color,
         size: body.size,
         notes: body.notes,
+        washingDetails: body.washingDetails,
       },
       viewOwner ?? userId,
     );
@@ -253,6 +255,7 @@ export class WardrobeController {
       color?: GarmentColor;
       size?: string;
       notes?: string;
+      washingDetails?: string;
     },
     @Req() req: FastifyRequest,
     @Res() reply: FastifyReply,
@@ -275,6 +278,7 @@ export class WardrobeController {
         color: body.color,
         size: body.size,
         notes: body.notes,
+        washingDetails: body.washingDetails,
       },
       viewOwner ?? userId,
       userId,

--- a/views/wardrobe/form.hbs
+++ b/views/wardrobe/form.hbs
@@ -80,6 +80,16 @@
     </div>
 
     <div class="form-control">
+      <label class="label"><span class="label-text">{{t 'lang.WASHING_DETAILS'}}</span></label>
+      <textarea
+        name="washingDetails"
+        class="textarea textarea-bordered"
+        rows="3"
+        placeholder="Wash at 30°C, do not tumble dry, do not iron…"
+      >{{#if garment}}{{garment.washingDetails}}{{/if}}</textarea>
+    </div>
+
+    <div class="form-control">
       <label class="label"><span class="label-text">{{t 'lang.NOTES'}}</span></label>
       <textarea
         name="notes"

--- a/views/wardrobe/show.hbs
+++ b/views/wardrobe/show.hbs
@@ -185,6 +185,11 @@
         <span class="text-base-content/60 text-sm">{{t 'lang.COLOR'}}</span>
         <span class="capitalize font-medium">{{garment.color}}</span>
       </div>
+      {{/if}} {{#if garment.washingDetails}}
+      <div class="flex flex-col gap-1">
+        <span class="text-base-content/60 text-sm">{{t 'lang.WASHING_DETAILS'}}</span>
+        <p class="text-sm">{{garment.washingDetails}}</p>
+      </div>
       {{/if}} {{#if garment.notes}}
       <div class="flex flex-col gap-1">
         <span class="text-base-content/60 text-sm">{{t 'lang.NOTES'}}</span>


### PR DESCRIPTION
Closes #25

## Garment Washing Details

Adds an optional `washingDetails` text field for care instructions.

### Changes
- **`washingDetails` text property** on Garment entity (optional)
- **Textarea** in garment create/edit form
- **Display** on garment show page metadata card
- **i18n keys** for all 6 supported languages
- **SQLite & PostgreSQL migrations**

_Screenshots in comments below._