### PR TITLE
Fix missing Camera option on Chrome/Android for garment photo upload

### DIFF
--- a/src/i18n/de/lang.json
+++ b/src/i18n/de/lang.json
@@ -99,6 +99,7 @@
   "ADD_FIRST_OUTFIT": "Erstes Outfit erstellen",
   "GARMENTS_IN_OUTFIT": "Kleidungsstücke in diesem Outfit",
   "ADD_PHOTO": "Foto hinzufügen",
+  "TAKE_PHOTO": "Foto aufnehmen",
   "UPDATE_PHOTO": "Foto aktualisieren",
   "BG_REMOVAL_TOGGLE": "Hintergrund automatisch entfernen",
   "REMOVING_BACKGROUND": "Hintergrund wird entfernt…",

--- a/src/i18n/en/lang.json
+++ b/src/i18n/en/lang.json
@@ -99,6 +99,7 @@
   "ADD_FIRST_OUTFIT": "Build your first outfit",
   "GARMENTS_IN_OUTFIT": "Garments in this outfit",
   "ADD_PHOTO": "Add Photo",
+  "TAKE_PHOTO": "Take Photo",
   "UPDATE_PHOTO": "Update Photo",
   "BG_REMOVAL_TOGGLE": "Auto-remove background",
   "REMOVING_BACKGROUND": "Removing background…",

--- a/src/i18n/es/lang.json
+++ b/src/i18n/es/lang.json
@@ -99,6 +99,7 @@
   "ADD_FIRST_OUTFIT": "Crea tu primer conjunto",
   "GARMENTS_IN_OUTFIT": "Prendas en este conjunto",
   "ADD_PHOTO": "Añadir foto",
+  "TAKE_PHOTO": "Tomar foto",
   "UPDATE_PHOTO": "Actualizar foto",
   "BG_REMOVAL_TOGGLE": "Eliminar fondo automáticamente",
   "REMOVING_BACKGROUND": "Eliminando fondo…",

--- a/src/i18n/fr/lang.json
+++ b/src/i18n/fr/lang.json
@@ -99,6 +99,7 @@
   "ADD_FIRST_OUTFIT": "Créez votre première tenue",
   "GARMENTS_IN_OUTFIT": "Vêtements dans cette tenue",
   "ADD_PHOTO": "Ajouter une photo",
+  "TAKE_PHOTO": "Prendre une photo",
   "UPDATE_PHOTO": "Mettre à jour la photo",
   "BG_REMOVAL_TOGGLE": "Suppression auto du fond",
   "REMOVING_BACKGROUND": "Suppression du fond…",

--- a/src/i18n/it/lang.json
+++ b/src/i18n/it/lang.json
@@ -99,6 +99,7 @@
   "ADD_FIRST_OUTFIT": "Crea il tuo primo outfit",
   "GARMENTS_IN_OUTFIT": "Capi in questo outfit",
   "ADD_PHOTO": "Aggiungi Foto",
+  "TAKE_PHOTO": "Scatta foto",
   "UPDATE_PHOTO": "Aggiorna Foto",
   "BG_REMOVAL_TOGGLE": "Rimuovi sfondo automaticamente",
   "REMOVING_BACKGROUND": "Rimozione sfondo…",

--- a/src/i18n/ru/lang.json
+++ b/src/i18n/ru/lang.json
@@ -90,6 +90,7 @@
   "ADD_FIRST_OUTFIT": "Создайте первый образ",
   "GARMENTS_IN_OUTFIT": "Вещи в этом образе",
   "ADD_PHOTO": "Добавить фото",
+  "TAKE_PHOTO": "Сделать фото",
   "UPDATE_PHOTO": "Обновить фото",
   "BG_REMOVAL_TOGGLE": "Автоудаление фона",
   "REMOVING_BACKGROUND": "Удаление фона…",

--- a/test/camera-capture.spec.ts
+++ b/test/camera-capture.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Regression test for https://github.com/lazztech/Libre-Closet/issues/99 —
+ * Chrome on Android was dropping the Camera option from the garment photo
+ * file-input's chooser sheet. The fix adds a dedicated "Take Photo" button
+ * wired to a hidden input with capture="environment", which launches the
+ * camera directly instead of depending on Chromium's merged chooser sheet.
+ */
+test('garment photo upload offers a direct camera capture entry point', async ({
+  page,
+}) => {
+  const email = `camera-test-${Date.now()}@example.com`;
+  const password = 'Password123!';
+
+  // Registration and garment creation are exercised elsewhere; set up state
+  // directly via the same cookie-sharing request context so this test stays
+  // focused on the capture-button behavior under test.
+  await page.request.post('/auth/register', {
+    form: { email, password, confirmPassword: password },
+  });
+  const createResponse = await page.request.post('/wardrobe', {
+    form: { name: 'Camera Test Garment', category: 'shirt' },
+  });
+  const garmentId = new URL(createResponse.url()).pathname
+    .split('/')
+    .pop();
+
+  await page.goto(`/wardrobe/${garmentId}`);
+
+  const captureButton = page.locator('#photoCaptureBtn');
+  await expect(captureButton).toBeVisible();
+
+  const [fileChooser] = await Promise.all([
+    page.waitForEvent('filechooser'),
+    captureButton.click(),
+  ]);
+
+  const captureInput = fileChooser.element();
+  expect(await captureInput.getAttribute('capture')).toBe('environment');
+  expect(await captureInput.getAttribute('accept')).toMatch(/image/);
+  expect(fileChooser.isMultiple()).toBe(false);
+
+  // Gallery/file browsing must remain unaffected by the new capture input.
+  await expect(page.locator('#photoInput')).not.toHaveAttribute('capture');
+});

--- a/test/camera-capture.spec.ts
+++ b/test/camera-capture.spec.ts
@@ -22,9 +22,7 @@ test('garment photo upload offers a direct camera capture entry point', async ({
   const createResponse = await page.request.post('/wardrobe', {
     form: { name: 'Camera Test Garment', category: 'shirt' },
   });
-  const garmentId = new URL(createResponse.url()).pathname
-    .split('/')
-    .pop();
+  const garmentId = new URL(createResponse.url()).pathname.split('/').pop();
 
   await page.goto(`/wardrobe/${garmentId}`);
 

--- a/views/wardrobe/show.hbs
+++ b/views/wardrobe/show.hbs
@@ -100,6 +100,40 @@
         class="file-input file-input-sm flex-1"
         accept="image/jpeg,image/png,image/gif,image/webp"
       />
+      <input
+        type="file"
+        id="photoCaptureInput"
+        class="hidden"
+        accept="image/jpeg,image/png,image/gif,image/webp"
+        capture="environment"
+      />
+      <button
+        id="photoCaptureBtn"
+        type="button"
+        class="btn btn-neutral btn-sm btn-square"
+        title="{{t 'lang.TAKE_PHOTO'}}"
+        aria-label="{{t 'lang.TAKE_PHOTO'}}"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="size-4"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M6.827 6.175A2.31 2.31 0 0 1 5.186 7.23c-.38.054-.757.112-1.134.174C2.999 7.58 2.25 8.507 2.25 9.574V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9.574c0-1.067-.75-1.994-1.802-2.169a47.865 47.865 0 0 0-1.134-.175 2.31 2.31 0 0 1-1.64-1.055l-.822-1.316a2.192 2.192 0 0 0-1.736-1.039 48.774 48.774 0 0 0-6.232 0 2.192 2.192 0 0 0-1.736 1.039l-.821 1.316Z"
+          />
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M16.5 12.75a4.5 4.5 0 1 1-9 0 4.5 4.5 0 0 1 9 0ZM18.75 10.5h.008v.008h-.008V10.5Z"
+          />
+        </svg>
+      </button>
       <button id="photoBtn" class="btn btn-neutral btn-sm" disabled>
         {{#if garment.photo}}{{t 'lang.UPDATE_PHOTO'}}{{else}}{{t
         'lang.ADD_PHOTO'}}{{/if}}
@@ -158,6 +192,24 @@
           photoInput.dispatchEvent(new Event('change'));
         }
       }
+    });
+
+    // Some Chrome/Android versions drop the Camera option from the gallery
+    // file-input's chooser sheet depending on the `accept` value (see
+    // https://github.com/lazztech/Libre-Closet/issues/99). A dedicated
+    // input with `capture="environment"` sidesteps that by launching the
+    // camera app directly, so route its selection into the same upload path.
+    const photoCaptureBtn = document.getElementById('photoCaptureBtn');
+    const photoCaptureInput = document.getElementById('photoCaptureInput');
+    const photoInputEl = document.getElementById('photoInput');
+    photoCaptureBtn?.addEventListener('click', () => photoCaptureInput?.click());
+    photoCaptureInput?.addEventListener('change', () => {
+      const file = photoCaptureInput.files?.[0];
+      if (!file || !photoInputEl) return;
+      const dt = new DataTransfer();
+      dt.items.add(file);
+      photoInputEl.files = dt.files;
+      photoInputEl.dispatchEvent(new Event('change'));
     });
 
     wireUpPhotoInput();


### PR DESCRIPTION
Fixes lazztech/Libre-Closet#99

## Problem
On Chrome for Android, the garment photo file-input's chooser sheet was dropping the "Camera" option, leaving only gallery/file browsing. Firefox on the same device was unaffected.

## Root cause
The input's explicit MIME list (`accept="image/jpeg,image/png,image/gif,image/webp"`) triggers a known Chromium quirk where the merged photo/video chooser sheet inconsistently omits Camera depending on the Android/Chrome version combination.

## Fix
- Adds a dedicated "Take Photo" button next to the existing gallery input on the garment detail page.
- The button triggers a hidden `<input type="file" capture="environment">` that launches the camera app directly, bypassing the chooser-sheet bug.
- The selected photo is routed into the existing upload path via the DataTransfer API, so the rest of the upload flow (crop/mask editor, save) is unchanged.
- The existing gallery input is untouched (no `capture` attribute).
- Adds a Playwright regression test covering the new button and asserting the gallery input keeps no `capture` attribute.
- Adds i18n strings for the new button label in all supported locales.

## Testing
- `npm test`: 18/18 passing.
- Playwright regression spec run on desktop and Mobile Chrome (Pixel 5) viewports.

This changes were written with AI assistance.
