### PR TITLE
Add explicit save confirmation to garment upload flow

### DIFF
--- a/src/i18n/en/lang.json
+++ b/src/i18n/en/lang.json
@@ -100,6 +100,8 @@
   "GARMENTS_IN_OUTFIT": "Garments in this outfit",
   "ADD_PHOTO": "Add Photo",
   "UPDATE_PHOTO": "Update Photo",
+  "GARMENT_SAVED": "Garment saved!",
+  "PHOTO_SAVED": "Photo saved!",
   "BG_REMOVAL_TOGGLE": "Auto-remove background",
   "REMOVING_BACKGROUND": "Removing background…",
   "BG_STAGE_DOWNLOADING": "Downloading assets…",

--- a/src/wardrobe/wardrobe.controller.ts
+++ b/src/wardrobe/wardrobe.controller.ts
@@ -177,8 +177,9 @@ export class WardrobeController {
       viewOwner ?? userId,
     );
 
-    const redirectSuffix = viewOwner ? `?ownerId=${viewOwner}` : '';
-    return reply.redirect(`/wardrobe/${garment.id}${redirectSuffix}`, 302);
+    const params = new URLSearchParams({ created: '1' });
+    if (viewOwner) params.set('ownerId', String(viewOwner));
+    return reply.redirect(`/wardrobe/${garment.id}?${params}`, 302);
   }
 
   @Get(':id')
@@ -188,6 +189,8 @@ export class WardrobeController {
     @Req() req: FastifyRequest,
     @I18n() i18n: I18nContext,
     @Query('ownerId') ownerId: string | undefined,
+    @Query('created') created: string | undefined,
+    @Query('photoSaved') photoSaved: string | undefined,
   ) {
     const userId = this.userId(req);
     const viewOwner = ownerId ? parseInt(ownerId, 10) : undefined;
@@ -220,6 +223,8 @@ export class WardrobeController {
       canDelete,
       canClone,
       viewOwner: viewOwner ?? null,
+      justCreated: created === '1',
+      justSavedPhoto: photoSaved === '1',
     };
   }
 
@@ -403,8 +408,9 @@ export class WardrobeController {
       viewOwner ?? userId,
       userId,
     );
-    const redirectSuffix = viewOwner ? `?ownerId=${viewOwner}` : '';
-    reply.header('HX-Redirect', `/wardrobe/${id}${redirectSuffix}`);
+    const params = new URLSearchParams({ photoSaved: '1' });
+    if (viewOwner) params.set('ownerId', String(viewOwner));
+    reply.header('HX-Redirect', `/wardrobe/${id}?${params}`);
     return reply.send();
   }
 

--- a/views/wardrobe/show.hbs
+++ b/views/wardrobe/show.hbs
@@ -343,4 +343,33 @@
   </dialog>
 </main>
 
+{{#if justCreated}}
+<div id="garment-saved-toast" class="toast toast-top toast-center z-20 top-20" aria-live="polite" _="init wait 4s then add .hidden to me">
+  <div class="alert alert-success shadow-md">
+    <svg xmlns="http://www.w3.org/2000/svg" class="size-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+    <span>{{t 'lang.GARMENT_SAVED'}}</span>
+  </div>
+</div>
+{{/if}} {{#if justSavedPhoto}}
+<div id="photo-saved-toast" class="toast toast-top toast-center z-20 top-20" aria-live="polite" _="init wait 4s then add .hidden to me">
+  <div class="alert alert-success shadow-md">
+    <svg xmlns="http://www.w3.org/2000/svg" class="size-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+    <span>{{t 'lang.PHOTO_SAVED'}}</span>
+  </div>
+</div>
+{{/if}}
+<script>
+  {{! Strip the one-shot save flags so refreshing or sharing this URL doesn't replay the toast }}
+  var savedFlagUrl = new URL(window.location.href);
+  if (savedFlagUrl.searchParams.has('created') || savedFlagUrl.searchParams.has('photoSaved')) {
+    savedFlagUrl.searchParams.delete('created');
+    savedFlagUrl.searchParams.delete('photoSaved');
+    window.history.replaceState({}, '', savedFlagUrl);
+  }
+</script>
+
 {{>dock}}

--- a/views/wardrobe/show.hbs
+++ b/views/wardrobe/show.hbs
@@ -344,7 +344,7 @@
 </main>
 
 {{#if justCreated}}
-<div id="garment-saved-toast" class="toast toast-top toast-center z-20 top-20" aria-live="polite" _="init wait 4s then add .hidden to me">
+<div id="garment-saved-toast" class="toast toast-top toast-center z-20 top-36" aria-live="polite" _="init wait 4s then add .hidden to me">
   <div class="alert alert-success shadow-md">
     <svg xmlns="http://www.w3.org/2000/svg" class="size-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
@@ -353,7 +353,7 @@
   </div>
 </div>
 {{/if}} {{#if justSavedPhoto}}
-<div id="photo-saved-toast" class="toast toast-top toast-center z-20 top-20" aria-live="polite" _="init wait 4s then add .hidden to me">
+<div id="photo-saved-toast" class="toast toast-top toast-center z-20 top-36" aria-live="polite" _="init wait 4s then add .hidden to me">
   <div class="alert alert-success shadow-md">
     <svg xmlns="http://www.w3.org/2000/svg" class="size-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />


### PR DESCRIPTION
Fixes #15 

## Summary
- Garment create and photo upload previously redirected silently with no confirmation the save worked (lazztech/Libre-Closet#15)
- Adds auto-dismissing "Garment saved!" / "Photo saved!" toasts after create and photo upload
- Cleans up the success URL flag so a page refresh does not replay the toast

## Testing
- Full Playwright regression at desktop and mobile viewports, plus form validation and console-error checks -- all passing
- Verified toast placement does not overlap the garment title heading or bottom navigation dock at either viewport
- Unit suite: 13/13 passing

This change was written with AI assistance.
