### PR TITLE
fix(outfits): pre-select first garment in builder and fix Handlebars rendering

### DIFF
--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -1,8 +1,12 @@
 name: Github Actions CI
-on: [push]
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
 
 env:
-  NODE_VERSION: '22.x' # set this to the node version to use
+  NODE_VERSION: "22.x" # set this to the node version to use
 
 jobs:
   back-end-ci:
@@ -66,10 +70,10 @@ jobs:
       - name: start postgresql db
         uses: harmon758/postgresql-action@v1
         with:
-          postgresql version: '11' # See https://hub.docker.com/_/postgres for available versions
-          postgresql db: 'postgres-test'
-          postgresql user: 'test'
-          postgresql password: 'Password123'
+          postgresql version: "11" # See https://hub.docker.com/_/postgres for available versions
+          postgresql db: "postgres-test"
+          postgresql user: "test"
+          postgresql password: "Password123"
 
       - name: start minio s3 object storage
         run: |
@@ -98,11 +102,11 @@ jobs:
           EMAIL_PASSWORD: test
           DATABASE_TYPE: postgres
           DATABASE_HOST: localhost
-          DATABASE_PORT: '5432'
-          DATABASE_USER: 'test'
-          DATABASE_PASS: 'Password123'
-          DATABASE_SCHEMA: 'postgres-test'
-          DATABASE_SSL: 'false'
+          DATABASE_PORT: "5432"
+          DATABASE_USER: "test"
+          DATABASE_PASS: "Password123"
+          DATABASE_SCHEMA: "postgres-test"
+          DATABASE_SSL: "false"
           FILE_STORAGE_TYPE: object
           OBJECT_STORAGE_BUCKET_NAME: test-lazztech-boilerplate
           OBJECT_STORAGE_ACCESS_KEY_ID: minioadmin
@@ -121,11 +125,11 @@ jobs:
           EMAIL_PASSWORD: test
           DATABASE_TYPE: postgres
           DATABASE_HOST: localhost
-          DATABASE_PORT: '5432'
-          DATABASE_USER: 'test'
-          DATABASE_PASS: 'Password123'
-          DATABASE_SCHEMA: 'postgres-test'
-          DATABASE_SSL: 'false'
+          DATABASE_PORT: "5432"
+          DATABASE_USER: "test"
+          DATABASE_PASS: "Password123"
+          DATABASE_SCHEMA: "postgres-test"
+          DATABASE_SSL: "false"
           FILE_STORAGE_TYPE: object
           OBJECT_STORAGE_BUCKET_NAME: test-lazztech-boilerplate
           OBJECT_STORAGE_ACCESS_KEY_ID: minioadmin

--- a/src/open-graph/open-graph.service.ts
+++ b/src/open-graph/open-graph.service.ts
@@ -93,6 +93,7 @@ export class OpenGraphService {
         ogDescription: `From ${createdBy?.email}`,
         ogImage,
         outfit,
+        garments: outfit?.garments.getItems() ?? [],
         createdBy,
       };
     }

--- a/src/wardrobe/outfit.controller.ts
+++ b/src/wardrobe/outfit.controller.ts
@@ -116,7 +116,8 @@ export class OutfitController {
     const garments = await this.garmentService.findAll(this.userId(req));
     const items = garments.filter((g) => g.category === category);
     const count = items.length;
-    const idx = Math.min(Math.max(parseInt(indexStr) || 0, 0), count);
+    const rawIdx = indexStr !== undefined && indexStr !== '' ? parseInt(indexStr) : 1;
+    const idx = Math.min(Math.max(isNaN(rawIdx) ? 1 : rawIdx, 0), count);
     const row = this.outfitService.buildRow(category, items, idx, i18n);
     return reply.viewPartial('partials/outfit_row', { row });
   }
@@ -128,7 +129,8 @@ export class OutfitController {
     @Req() req: FastifyRequest,
   ) {
     const outfit = await this.outfitService.findOne(id, this.userId(req));
-    return { outfit };
+    const garments = outfit.garments.getItems();
+    return { outfit, garments };
   }
 
   @Get(':id/edit')

--- a/src/wardrobe/outfit.controller.ts
+++ b/src/wardrobe/outfit.controller.ts
@@ -116,7 +116,8 @@ export class OutfitController {
     const garments = await this.garmentService.findAll(this.userId(req));
     const items = garments.filter((g) => g.category === category);
     const count = items.length;
-    const rawIdx = indexStr !== undefined && indexStr !== '' ? parseInt(indexStr) : 1;
+    const rawIdx =
+      indexStr !== undefined && indexStr !== '' ? parseInt(indexStr) : 1;
     const idx = Math.min(Math.max(isNaN(rawIdx) ? 1 : rawIdx, 0), count);
     const row = this.outfitService.buildRow(category, items, idx, i18n);
     return reply.viewPartial('partials/outfit_row', { row });

--- a/src/wardrobe/outfit.service.ts
+++ b/src/wardrobe/outfit.service.ts
@@ -161,10 +161,16 @@ export class OutfitService {
       category: string,
       items: Garment[],
       selectedId: number | null,
+      defaultFirst = false,
     ) => {
       const selectedIdx =
         selectedId != null ? items.findIndex((g) => g.id === selectedId) : -1;
-      const idx = selectedIdx >= 0 ? selectedIdx + 1 : 0;
+      let idx = 0;
+      if (selectedIdx >= 0) {
+        idx = selectedIdx + 1;
+      } else if (defaultFirst && items.length > 0) {
+        idx = 1;
+      }
       return this.buildRow(category, items, idx, i18n);
     };
 
@@ -178,7 +184,7 @@ export class OutfitService {
             slot.garmentId != null
               ? (items.find((g) => g.id === slot.garmentId) ?? null)
               : null;
-          return toRow(slot.category, items, selected?.id ?? null);
+          return toRow(slot.category, items, selected?.id ?? null, false);
         });
     }
 
@@ -195,7 +201,7 @@ export class OutfitService {
     return orderedKeys.map((cat) => {
       const items = grouped[cat]!;
       const selected = items.find((g) => selectedIds.includes(g.id)) ?? null;
-      return toRow(cat, items, selected?.id ?? null);
+      return toRow(cat, items, selected?.id ?? null, true);
     });
   }
 

--- a/views/outfits/show.hbs
+++ b/views/outfits/show.hbs
@@ -25,9 +25,9 @@
   <p class="text-base-content/60 text-sm mb-6 px-1">{{outfit.notes}}</p>
   {{/if}} {{!-- Garments grid --}}
   <h2 class="font-semibold mb-3">{{t 'lang.GARMENTS_IN_OUTFIT'}}</h2>
-  {{#if outfit.garments.length}}
+  {{#if garments.length}}
   <div class="flex flex-wrap gap-3 mb-8">
-    {{#each outfit.garments}}
+    {{#each garments}}
     <a
       href="/wardrobe/{{this.id}}"
       class="flex flex-col items-center gap-1 w-24"

--- a/views/share.hbs
+++ b/views/share.hbs
@@ -42,9 +42,9 @@
       <h2 class="card-title">{{outfit.name}}</h2>
       {{#if outfit.notes}}
       <p class="text-base-content/60 text-sm">{{outfit.notes}}</p>
-      {{/if}} {{#if outfit.garments.length}}
+      {{/if}} {{#if garments.length}}
       <div class="flex flex-wrap gap-2">
-        {{#each outfit.garments}} {{#if this.photo}}
+        {{#each garments}} {{#if this.photo}}
         <img src="/file/nobg/{{this.photo.fileName}}" alt="{{this.name}}"
           class="size-20 rounded-box object-cover shadow-sm" />
         {{else}}


### PR DESCRIPTION
This PR resolves two issues in the Outfit Builder:                                                                                                                                                       
                                                                                                                                                                                                             
   1. **Builder Row Pre-selection**: When opening `/outfits/new`, category rows defaulted to index `0` (`—` / empty selection). Creating an outfit without toggling every row resulted in empty garment IDs 
  being submitted. New outfit builder rows now default to index `1` (the 1st garment in that category).                                                                                                      
                                                                                                                                                                                                             
   2. **Handlebars Prototype Access**: In `show.hbs` and `share.hbs`, checking `{{#if outfit.garments.length}}` triggered a Handlebars prototype access security warning because `outfit.garments` is a     
  MikroORM `Collection` instance. Converted `outfit.garments` to a plain array (`.getItems()`) in the controllers/services and updated templates to check `garments.length`.