### PR TITLE
fix(migrations): stop the v0.4.0 garment rebuild from deleting outfit_garments (#129)

### DIFF
--- a/src/dal/migrations/sqlite/Migration20260612010037.ts
+++ b/src/dal/migrations/sqlite/Migration20260612010037.ts
@@ -9,6 +9,13 @@ export class Migration20260612010037 extends Migration {
     this.addSql(`create unique index \`wardrobe_share_invite_token_unique\` on \`wardrobe_share\` (\`invite_token\`);`);
     this.addSql(`create unique index \`wardrobe_share_grantor_id_grantee_id_unique\` on \`wardrobe_share\` (\`grantor_id\`, \`grantee_id\`);`);
 
+    // `pragma foreign_keys = off` is a no-op inside a transaction, and migrations
+    // run transactionally. FK enforcement therefore stays on, and the `drop table
+    // \`garment\`` below cascade-deletes every `outfit_garments` row (see #129).
+    // Stash the join rows and put them back once `garment` has been rebuilt.
+    this.addSql(`create table \`outfit_garments__129_backup\` (\`outfit_id\` integer not null, \`garment_id\` integer not null);`);
+    this.addSql(`insert into \`outfit_garments__129_backup\` select \`outfit_id\`, \`garment_id\` from \`outfit_garments\`;`);
+
     this.addSql(`pragma foreign_keys = off;`);
     this.addSql(`create table \`garment__temp_alter\` (\`id\` integer not null primary key autoincrement, \`shareable_id\` text not null, \`flagged\` integer null, \`banned\` integer null, \`name\` text null, \`category\` text not null, \`color\` integer null, \`brand\` text null, \`size\` text null, \`notes\` text null, \`photo_id\` integer null, \`owner_id\` integer null, constraint \`garment_photo_id_foreign\` foreign key(\`photo_id\`) references \`file\`(\`id\`) on delete set null on update cascade, constraint \`garment_owner_id_foreign\` foreign key(\`owner_id\`) references \`user\`(\`id\`) on delete cascade on update cascade);`);
     this.addSql(`insert into \`garment__temp_alter\` select \`id\`, \`shareable_id\`, \`flagged\`, \`banned\`, \`name\`, \`category\`, \`color\`, \`brand\`, \`size\`, \`notes\`, \`photo_id\`, \`owner_id\` from \`garment\`;`);
@@ -17,6 +24,11 @@ export class Migration20260612010037 extends Migration {
     this.addSql(`create unique index \`garment_photo_id_unique\` on \`garment\` (\`photo_id\`);`);
     this.addSql(`create index \`garment_owner_id_index\` on \`garment\` (\`owner_id\`);`);
     this.addSql(`pragma foreign_keys = on;`);
+
+    // `insert or ignore` so this stays correct if the pragma ever does take
+    // effect: the rows would still be there and the restore becomes a no-op.
+    this.addSql(`insert or ignore into \`outfit_garments\` (\`outfit_id\`, \`garment_id\`) select \`outfit_id\`, \`garment_id\` from \`outfit_garments__129_backup\`;`);
+    this.addSql(`drop table \`outfit_garments__129_backup\`;`);
   }
 
 }

--- a/src/dal/sqlite-migrations.spec.ts
+++ b/src/dal/sqlite-migrations.spec.ts
@@ -1,0 +1,109 @@
+import { BetterSqliteDriver } from '@mikro-orm/better-sqlite';
+import { MikroORM } from '@mikro-orm/core';
+import { Migration, Migrator } from '@mikro-orm/migrations';
+import { mkdtempSync, readdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+/**
+ * Guards against migrations that silently destroy user data.
+ *
+ * SQLite cannot alter a column in place, so MikroORM emits a full table
+ * rebuild (create temp -> copy -> drop original -> rename). `DROP TABLE` runs
+ * an implicit `DELETE FROM` that fires `ON DELETE CASCADE`, and the
+ * `pragma foreign_keys = off` that is supposed to prevent that is a no-op
+ * inside a transaction -- which is how migrations run here. That combination
+ * wiped every `outfit_garments` row on upgrade (#129).
+ *
+ * This test seeds a database at the last pre-regression migration and then runs
+ * the rest of the chain, asserting that no table loses rows.
+ */
+
+/** Last migration shipped in v0.3.2 -- the baseline reported in #129. */
+const SEED_AFTER_MIGRATION = 'Migration20260416215236';
+
+const MIGRATIONS_DIR = join(__dirname, 'migrations', 'sqlite');
+
+const migrationsList = readdirSync(MIGRATIONS_DIR)
+  .filter((file) => /^Migration\d+\.(ts|js)$/.test(file))
+  .sort()
+  .map((file) => {
+    const name = file.replace(/\.(ts|js)$/, '');
+    // Loaded dynamically so a newly generated migration is covered without
+    // anyone having to remember to add it here.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const loaded = require(join(MIGRATIONS_DIR, file)) as Record<
+      string,
+      typeof Migration
+    >;
+    return { name, class: loaded[name] };
+  });
+
+const SEED_STATEMENTS = [
+  `insert into \`password_reset\` (\`id\`, \`pin\`) values (1, '123456');`,
+  `insert into \`user\` (\`id\`, \`shareable_id\`, \`email\`, \`password\`) values (1, 'user-1', 'owner@example.com', 'hashed');`,
+  `insert into \`file\` (\`id\`, \`shareable_id\`, \`file_name\`, \`created_on\`, \`created_by_id\`) values (1, 'file-1', 'shirt.jpg', '2026-04-01', 1), (2, 'file-2', 'jeans.jpg', '2026-04-01', 1);`,
+  `insert into \`garment\` (\`id\`, \`shareable_id\`, \`name\`, \`category\`, \`color\`, \`photo_id\`, \`owner_id\`) values (1, 'garment-1', 'Shirt', 'TOP', 'blue', 1, 1), (2, 'garment-2', 'Jeans', 'BOTTOM', 'black', 2, 1), (3, 'garment-3', 'Boots', 'SHOES', 'brown', null, 1);`,
+  `insert into \`outfit\` (\`id\`, \`shareable_id\`, \`name\`, \`owner_id\`) values (1, 'outfit-1', 'Workday', 1), (2, 'outfit-2', 'Weekend', 1);`,
+  `insert into \`outfit_garments\` (\`outfit_id\`, \`garment_id\`) values (1, 1), (1, 2), (2, 2), (2, 3);`,
+  `insert into \`outfit_calendar\` (\`id\`, \`date\`, \`outfit_id\`, \`owner_id\`) values (1, '2026-04-02', 1, 1), (2, '2026-04-03', 2, 1);`,
+];
+
+describe('sqlite migrations', () => {
+  let dir: string;
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    dir = mkdtempSync(join(tmpdir(), 'libre-closet-migrations-'));
+    orm = await MikroORM.init({
+      driver: BetterSqliteDriver,
+      dbName: join(dir, 'sqlite3.db'),
+      entities: [],
+      discovery: { warnWhenNoEntities: false },
+      extensions: [Migrator],
+      logger: () => undefined,
+      migrations: { migrationsList, transactional: true },
+    });
+  });
+
+  afterAll(async () => {
+    await orm?.close(true);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const countRows = async (): Promise<Record<string, number>> => {
+    const connection = orm.em.getConnection();
+    const tables = await connection.execute<{ name: string }[]>(
+      `select \`name\` from \`sqlite_master\` where \`type\` = 'table' and \`name\` not like 'sqlite_%' and \`name\` != 'mikro_orm_migrations';`,
+    );
+
+    const counts: Record<string, number> = {};
+    for (const { name } of tables) {
+      const [row] = await connection.execute<{ count: number }[]>(
+        `select count(*) as \`count\` from \`${name}\`;`,
+      );
+      counts[name] = row.count;
+    }
+    return counts;
+  };
+
+  it('preserves every row when upgrading a v0.3.2 database (#129)', async () => {
+    const migrator = orm.getMigrator();
+
+    await migrator.up({ to: SEED_AFTER_MIGRATION });
+    for (const statement of SEED_STATEMENTS) {
+      await orm.em.getConnection().execute(statement);
+    }
+
+    const before = await countRows();
+    // Sanity check: the fixture must actually exercise the join table.
+    expect(before['outfit_garments']).toBe(4);
+
+    await migrator.up();
+
+    const after = await countRows();
+    for (const [table, count] of Object.entries(before)) {
+      expect({ table, count: after[table] }).toEqual({ table, count });
+    }
+  });
+});


### PR DESCRIPTION
Fixes #129.

## The problem

`Migration20260612010037` (shipped in v0.4.0, still on `main`) rebuilds the `garment` table to change the `color` column — SQLite can't `ALTER COLUMN`, so MikroORM emits create-temp → copy → `drop table garment` → rename.

The rebuild starts with `pragma foreign_keys = off;`, which is meant to make that safe. It doesn't, for three reasons that only bite in combination:

1. `outfit_garments.garment_id` is declared `on delete cascade`.
2. In SQLite, `DROP TABLE` performs an implicit `DELETE FROM` first, and that **does** fire `ON DELETE CASCADE`.
3. [`PRAGMA foreign_keys` is a no-op inside a transaction](https://www.sqlite.org/pragma.html#pragma_foreign_keys), and `mikro-orm.sqlite.cli-config.ts` sets `migrations.transactional: true`, so the migration runner wraps every statement — including the pragma — in one.

So foreign keys stay enforced, `drop table garment` cascades, and every outfit↔garment link is deleted. No error is raised; the migration reports `Applied`.

Postgres is unaffected — `Migration20260612010041` uses `alter table "garment" alter column "color" type smallint`, with no table drop.

## Reproduction

Against a single SQLite file:

1. Run the v0.3.2 migration set against an empty database (7 migrations, through `Migration20260416215236`).
2. Seed a user, files, garments, outfits, `outfit_garments` rows and `outfit_calendar` rows.
3. Run the current `main` migration set against the same file.
4. `select count(*) from outfit_garments;`

| Table | Before | After |
|---|---|---|
| `user` | 1 | 1 |
| `file` | 3 | 3 |
| `garment` | 12 | 12 |
| `outfit` | 8 | 8 |
| **`outfit_garments`** | **24** | **0** |
| `outfit_calendar` | 8 | 8 |

That matches the report exactly: only the join table, silently.

Worth flagging that this is **not only historical**. Running a ≤ v0.3.2 database through the migration chain on current `main` (`aa3d616`) still gives 24 → 0, so anyone who has not upgraded yet is still exposed on their next upgrade — the group you mentioned wanting to size in the issue thread.

## What this PR does

It stashes the `outfit_garments` rows into a scratch table immediately before the rebuild, re-inserts them immediately after, and drops the scratch table. 12 lines in the migration.

- **The resulting schema is unchanged.** Dumping `sqlite_master` after running the full chain with and without this patch produces identical output.
- `insert or ignore` is deliberate: if a future SQLite or MikroORM ever makes the pragma effective inside a transaction, the rows are never deleted and the restore quietly becomes a no-op instead of a primary-key conflict.
- The migration name is unchanged, so it never re-runs for anyone who has already migrated.

It also adds `src/dal/sqlite-migrations.spec.ts`, which seeds a v0.3.2-shaped database, runs the rest of the migration chain, and asserts that no table loses rows. It fails on `main` (`outfit_garments` 4 → 0) and passes with the fix. It discovers migration files from disk rather than a hard-coded list, so future migrations are covered without anyone having to remember to update it — a table rebuild is a routine thing for MikroORM to emit against SQLite, and this failure mode can recur.

## What this PR does not do

- **It does not recover data already lost.** For anyone who has already upgraded, those rows were `DELETE`d rather than orphaned, and nothing in the schema retains them. Only a pre-upgrade file backup restores them, as the reporter found. A "recovery migration" would have nothing to read.
- **It does not change `migrations.transactional`.** Setting it to `false` for SQLite would make the pragma actually take effect and would fix the whole class of bug, but it trades away migration atomicity, and a half-applied migration on a self-hosted database is arguably a worse failure than this one. That seemed like a maintainer decision rather than something to fold into a bug fix.
- **It does not regenerate the schema snapshot.** Related aside in case it is useful: nothing about `color` actually changed between v0.3.2 and v0.4.0 — `GarmentColor` is a string enum and is byte-identical across those tags. The v0.4.0 snapshot diff shows `"enumItems": []` added to 39 columns alongside `color` flipping `text` → `integer`, which is what MikroORM emits when it cannot reflect enum members and falls back to a numeric enum. So the rebuild that destroyed the data came from a phantom schema diff. Regenerating the snapshot correctly would stop future phantom rebuilds, but doing it here risks emitting *another* `garment` rebuild for already-migrated users, so I left it alone.

Thanks for the quick acknowledgement on the issue — "a known issue and miss on our part" made it clear this was worth fixing rather than re-litigating.

## Verification

- `npx jest src/dal/sqlite-migrations.spec.ts` — fails on `main` (`outfit_garments` 4 → 0), passes with this change.
- `npm test` — 14 suites / 19 tests pass.
- `npx eslint` and `npx prettier --check` clean on both changed files.
- `sqlite_master` dump after the full migration chain is identical with and without the patch.

This change was written with AI assistance.
