### PR TITLE
fix(wardrobe): close unclosed div in garment detail metadata card

### DIFF
--- a/views/wardrobe/show.hbs
+++ b/views/wardrobe/show.hbs
@@ -248,6 +248,7 @@
       <div class="flex flex-col gap-1">
         <span class="text-base-content/60 text-sm">{{t 'lang.WASHING_DETAILS'}}</span>
         <p class="text-sm">{{garment.washingDetails}}</p>
+      </div>
       {{/if}} {{#if garment.dateAquired}}
       <div class="flex justify-between">
         <span class="text-base-content/60 text-sm">{{t 'lang.DATE_AQUIRED'}}</span>


### PR DESCRIPTION
## Problem

On the garment detail page (`/wardrobe/:id`), the "Washing details" block opens a `<div class="flex flex-col gap-1">` but never closes it. For any garment with washing details set, the following fields ("Date acquired", "Notes") render nested inside that container, and the metadata card ends with an unbalanced closing tag. Browsers silently recover, so the visible symptom is subtle (lost `gap-3` spacing, fields grouped under "Washing details"), but the emitted HTML is structurally malformed.

## Repro

1. Log in and open any garment -> Edit.
2. Enter a value in "Washing details" (optionally "Date acquired" / "Notes") and Save.
3. View the garment detail page and inspect the metadata card DOM: "Date acquired" and "Notes" render as children of the washing-details `<div>`, which has no closing tag.

## Fix

Add the missing `</div>` to close the washing-details container (1 line).

## Verification

- Rendered `views/wardrobe/show.hbs` with sample data; the emitted HTML is now balanced (24 open `<div>` vs 24 close `</div>`, previously 24 vs 23).
- `npm run generate:tailwind` passes.

This change was written with AI assistance