### PR TITLE
fix(wardrobe): make filter modal radios keyboard-accessible

### DIFF
--- a/views/wardrobe/index.hbs
+++ b/views/wardrobe/index.hbs
@@ -125,7 +125,7 @@
       <div class="flex flex-wrap gap-2">
         {{#each availableCategories}}
         <label class="cursor-pointer">
-          <input type="radio" name="modal-category" value="{{this.value}}" class="hidden peer"
+          <input type="radio" name="modal-category" value="{{this.value}}" class="sr-only peer"
             {{#ifEquals this.value ../search.category}}checked{{/ifEquals}}>
           <span class="badge badge-outline peer-checked:badge-primary capitalize select-none">{{this.label}}</span>
         </label>
@@ -139,7 +139,7 @@
       <div class="flex flex-wrap gap-2">
         {{#each colors}}
         <label class="cursor-pointer">
-          <input type="radio" name="modal-color" value="{{this}}" class="hidden peer"
+          <input type="radio" name="modal-color" value="{{this}}" class="sr-only peer"
             {{#ifEquals this ../search.color}}checked{{/ifEquals}}>
           <span class="badge badge-outline peer-checked:badge-secondary capitalize select-none">{{this}}</span>
         </label>
@@ -154,7 +154,7 @@
       <div class="flex flex-wrap gap-2">
         {{#each availableSizes}}
         <label class="cursor-pointer">
-          <input type="radio" name="modal-size" value="{{this}}" class="hidden peer"
+          <input type="radio" name="modal-size" value="{{this}}" class="sr-only peer"
             {{#ifEquals this ../search.size}}checked{{/ifEquals}}>
           <span class="badge badge-outline peer-checked:badge-accent select-none">{{this}}</span>
         </label>


### PR DESCRIPTION
## Problem

The Filter/Search modal on `/wardrobe` uses `<input type="radio" ... class="hidden peer">` for its Garment Type, Color, and Size options. `hidden` is `display: none`, which removes the radios from both the tab order and the accessibility tree. Mouse users can still click the associated badge (the label still fires the input), but keyboard-only and screen-reader users cannot select a category/color/size at all.

## Repro

1. Open `/wardrobe`, click "Filter / Search".
2. Try to reach and select a "Garment Type" option using only the keyboard (Tab/arrow keys) or a screen reader - no option is focusable or announced.
3. Contrast with mouse: clicking a badge selects the filter and "Apply Filters" works.

## Fix

Swap `hidden` for Tailwind's visually-hidden-but-focusable `sr-only` utility on the three radio groups, keeping `peer` so the badge styling (`peer-checked:badge-*`) still works.

## Verification

- Rendered `views/wardrobe/index.hbs` with sample data; all radio inputs now carry `class="sr-only peer"` (previously `hidden peer`), and are focusable/announced.
- `npm run generate:tailwind` passes; the compiled CSS contains `.sr-only` and the `peer-checked:badge-*` rules.

This change was written with AI assistance